### PR TITLE
Support UNC paths

### DIFF
--- a/config/backends.php
+++ b/config/backends.php
@@ -126,6 +126,9 @@ $backends['ftp'] = [
         // The type of the remote FTP server. Possible values: 'unix', 'win',
         // 'netware'. By default, we attempt to auto-detect type.
         // 'type' => 'unix',
+        // If true, MLSD command will be used to obtain directory listing
+        // (with auto fallback to non-MLSD mode, if not supported)
+        // 'mlsd' => false,
     ],
     'loginparams' => [
         // Allow the user to change the FTP server

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -112,7 +112,7 @@ class Gollem_Auth
         if (empty($backend['root'])) {
             $backend['root'] = '/';
         }
-        $backend['root'] = Horde_Util::realPath($backend['root']);
+        $backend['root'] = Gollem::realUncPath($backend['root']);
 
         // Make sure we have a 'home' parameter.
         if (empty($backend['home'])) {
@@ -129,7 +129,7 @@ class Gollem_Auth
         if (strpos($backend['home'], '/') !== 0) {
             $backend['home'] = $backend['root'] . '/' . $backend['home'];
         }
-        $backend['home'] = Horde_Util::realPath($backend['home']);
+        $backend['home'] = Gollem::realUncPath($backend['home']);
         $backend['dir'] = $backend['home'];
 
         // Verify that home is below root.

--- a/lib/Gollem.php
+++ b/lib/Gollem.php
@@ -51,7 +51,7 @@ class Gollem
      */
     public static function setDir($dir)
     {
-        $dir = Horde_Util::realPath($dir);
+        $dir = self::realUncPath($dir);
 
         if (!self::verifyDir($dir)
             || !self::checkPermissions('directory', Horde_Perms::READ, $dir)) {
@@ -305,7 +305,7 @@ class Gollem
      */
     public static function createFolder($dir, $name, $gollem_vfs = null)
     {
-        $totalpath = Horde_Util::realPath($dir . '/' . $name);
+        $totalpath = self::realUncPath($dir . '/' . $name);
         if (!self::verifyDir($totalpath)) {
             throw new Gollem_Exception(sprintf(_("Access denied to folder \"%s\"."), $totalpath));
         }
@@ -590,7 +590,7 @@ class Gollem
      */
     public static function verifyDir($dir)
     {
-        return Horde_String::substr(Horde_Util::realPath($dir), 0, Horde_String::length(self::$backend['root'])) == self::$backend['root'];
+        return Horde_String::substr(self::realUncPath($dir), 0, Horde_String::length(self::$backend['root'])) == self::$backend['root'];
     }
 
     /**
@@ -735,7 +735,7 @@ class Gollem
      */
     public static function getDisplayPath($path)
     {
-        $path = Horde_Util::realPath($path);
+        $path = self::realUncPath($path);
         if (self::$backend['root'] != '/'
             && strpos($path, self::$backend['root']) === 0) {
             $path = substr($path, Horde_String::length(self::$backend['root']));
@@ -839,6 +839,24 @@ class Gollem
                 }
                 return Horde::url('manager.php');
         }
+    }
+
+    /**
+     * Support UNC paths, for example, //server/share/path
+     *
+     */
+    public static function realUncPath($path)
+    {
+        $unc = substr($path, 0, 2) === '//';
+        if ($unc) {
+            $path = substr($path, 2);
+        }
+        $path = Horde_Util::realPath($path);
+        if ($unc) {
+            $path = '//' . $path;
+        }
+
+        return $path;
     }
 
 }


### PR DESCRIPTION
This adds a simple workaround to support paths starting with `//` in `Gollem` (essentially we preserve `//`).

A possibly better fix would be to redesign/simplify `Horde_Util::realpath()` instead.

Together with https://github.com/horde/Vfs/pull/7 it fixes issues with Netware/OES ftp servers.

Also describe `mlsd` parameter in `backends.php`.
